### PR TITLE
Update Pages workflow for WALLY Finder deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,43 +1,58 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy WALLY Finder to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  pull_request:
+    branches: ["main"]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
+      - name: Validate offline scripts
+        run: python -m compileall scripts_offline
+
+      - name: Prepare static bundle
+        run: |
+          mkdir -p dist
+          rsync -av --exclude '.git' --exclude '.github' --exclude 'dist' ./ dist
+          touch dist/.nojekyll
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: dist
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Aplicativo web mobile "Onde está Wally" construído com HTML/CSS/JS puro. O foc
 
 > ⚠️ Safari iOS exige HTTPS para acessar a câmera. Utilize `npx http-server --ssl` ou publique via localhost com certificado.
 
+## Publicação no GitHub Pages
+
+- Cada push ou pull request direcionado para `main` executa a pipeline **Deploy WALLY Finder to GitHub Pages** (`.github/workflows/static.yml`).
+- O job `build` compila rapidamente os utilitários Python (`python -m compileall scripts_offline`) para garantir que os scripts offline continuem válidos antes de preparar o pacote estático.
+- Os arquivos públicos são reunidos em `dist/` via `rsync`, com criação de `.nojekyll` para liberar o service worker e demais assets sem interferência do Jekyll.
+- Nos pushes para `main`, o job `deploy` publica o conteúdo preparado na aba **Pages** do repositório utilizando `actions/deploy-pages@v4`.
+- Para validar manualmente, acione o workflow por **Run workflow** ou use `workflow_dispatch` via Actions.
+
 ## Estrutura principal
 
 - `index.html` – Tela principal com vídeo, HUD e bottom sheet de achados.


### PR DESCRIPTION
## Summary
- restructure the GitHub Pages workflow to build a static bundle and run offline script validation before deployment
- document the new GitHub Pages publication flow in the README for future contributors

## Testing
- python -m compileall scripts_offline

------
https://chatgpt.com/codex/tasks/task_e_68d93abd56088324b53d185159c6da9c